### PR TITLE
board:knot: Create KNoT specific device_table.txt

### DIFF
--- a/board/knot/raspberrypi/device_table.txt
+++ b/board/knot/raspberrypi/device_table.txt
@@ -1,0 +1,6 @@
+# Device table for KNoT packages
+#
+# <name>				<type>	<mode>	<uid>	<gid>	<major>	<minor>	<start>	<inc>	<count>
+/usr/local/bin/knot-fog-source		r	755	1003	1003	-	-	-	-	-
+/usr/local/bin/knot-fog-connector	r	755	1003	1003	-	-	-	-	-
+/data/rabbitmq				r	755	1004	1004	-	-	-	-	-

--- a/configs/knot_raspberrypi3_defconfig
+++ b/configs/knot_raspberrypi3_defconfig
@@ -47,6 +47,7 @@ BR2_LINUX_KERNEL_VERSION="custom"
 BR2_LINUX_KERNEL_CONFIG_FRAGMENT_FILES="board/knot/raspberrypi/knot_linux_defconfig"
 
 BR2_ROOTFS_USERS_TABLES="board/knot/raspberrypi/rootfs_overlay/etc/knot/users"
+BR2_ROOTFS_DEVICE_TABLE="board/knot/raspberrypi/device_table.txt"
 
 # KNoT packages
 BR2_PACKAGE_KNOT_PROTOCOL_LIB=y

--- a/system/device_table.txt
+++ b/system/device_table.txt
@@ -17,8 +17,5 @@
 /etc/network/if-pre-up.d		d	755	0	0	-	-	-	-	-
 /etc/network/if-down.d			d	755	0	0	-	-	-	-	-
 /etc/network/if-post-down.d		d	755	0	0	-	-	-	-	-
-/usr/local/bin/knot-fog-source		r	755	1003	1003	-	-	-	-	-
-/usr/local/bin/knot-fog-connector	r	755	1003	1003	-	-	-	-	-
-/data/rabbitmq				r	755	1004	1004	-	-	-	-	-
 # uncomment this to allow starting x as non-root
 #/usr/X11R6/bin/Xfbdev		     	f	4755	0	0	-	-	-	-	-


### PR DESCRIPTION
Modifications in `system/` impact in any board that is built using buildroot. Thus, if one tries to build any board it will not be possible. Rather than modifying the system device_table, creating a new file
for KNoT boards only, as suggested in the buildroot documentation.