### PR TITLE
Update rabbitmq folder ownership to rabbitmq user

### DIFF
--- a/board/knot/raspberrypi/device_table.txt
+++ b/board/knot/raspberrypi/device_table.txt
@@ -3,4 +3,5 @@
 # <name>				<type>	<mode>	<uid>	<gid>	<major>	<minor>	<start>	<inc>	<count>
 /usr/local/bin/knot-fog-source		r	755	1003	1003	-	-	-	-	-
 /usr/local/bin/knot-fog-connector	r	755	1003	1003	-	-	-	-	-
+/usr/local/rabbitmq-server	        r	755	1004	1004	-	-	-	-	-
 /data/rabbitmq				r	755	1004	1004	-	-	-	-	-


### PR DESCRIPTION
After fixed the security issue that allowed any user to run applets as
root user (#36), the rabbitmq server could not start because it was
trying to write log files in a directory owned by the root user. That
is, the rabbitmq server is now running really as rabbitmq user.

In order to solve this issue, we need to change the ownership of the
rabbitmq directory in a way that the service can create what log files
it needs.