### PR TITLE
Set KNoT directories ownership with usernames

### DIFF
--- a/board/knot/raspberrypi/device_table.txt
+++ b/board/knot/raspberrypi/device_table.txt
@@ -1,6 +1,6 @@
 # Device table for KNoT packages
 #
-# <name>				<type>	<mode>	<uid>	<gid>	<major>	<minor>	<start>	<inc>	<count>
-/usr/local/bin/knot-fog-connector	r	755	1003	1003	-	-	-	-	-
-/usr/local/rabbitmq-server	        r	755	1004	1004	-	-	-	-	-
-/data/rabbitmq				r	755	1004	1004	-	-	-	-	-
+# <name>				<type>	<mode>    <uid>      <gid>    <major>  <minor>	<start>	<inc>	<count>
+/usr/local/bin/knot-fog-connector       r	755	  knot       knot	-	-	-	-	-
+/usr/local/rabbitmq-server              r	755	  rabbitmq   rabbitmq	-	-	-	-	-
+/data/rabbitmq                          r	755	  rabbitmq   rabbitmq	-	-	-	-	-


### PR DESCRIPTION
The directories permissions were being changed according to the user
and group numerical IDs defined in the board's device table, which was
causing them to be associated with the wrong user/group when a new
package was added. For example, when the postgresql package was added
it has assumed the '1004' ID but in the device table the same ID was
used as it was associated with the rabbitmq package.

The appropriate solution to this is to use actual name IDs instead of
the numerical ones, as referenced at the makedev syntax documentation:
https://buildroot.org/downloads/manual/manual.html#makedev-syntax.