### PR TITLE
package: knot-web: Remove knot service dependency

### DIFF
--- a/package/knot-web/Config.in
+++ b/package/knot-web/Config.in
@@ -1,6 +1,5 @@
 config BR2_PACKAGE_KNOT_WEB
     bool "knot-web"
-    depends on BR2_PACKAGE_KNOT_SERVICE_APP
     depends on BR2_PACKAGE_MONGODB
     select BR2_PACKAGE_NODEJS
     select BR2_PACKAGE_AVAHI


### PR DESCRIPTION
This patch removes KNoT service dependency from the WebUI package since it can now run without the `knotd` service.