### PR TITLE
Allow user knot to write in /etc/knot directory

### DIFF
--- a/board/knot/raspberrypi/device_table.txt
+++ b/board/knot/raspberrypi/device_table.txt
@@ -1,6 +1,7 @@
 # Device table for KNoT packages
 #
 # <name>				<type>	<mode>    <uid>      <gid>    <major>  <minor>	<start>	<inc>	<count>
+/etc/knot                               r	755	  knot       knot	-	-	-	-	-
 /usr/local/bin/knot-fog-connector       r	755	  knot       knot	-	-	-	-	-
 /usr/local/rabbitmq-server              r	755	  rabbitmq   rabbitmq	-	-	-	-	-
 /data/rabbitmq                          r	755	  rabbitmq   rabbitmq	-	-	-	-	-


### PR DESCRIPTION
This patch enables the user knot to edit the knot configuration files, which are currently placed on `/etc/knot` directory. The solution was to add an entry in our custom `device_table` file. It will avoid the WebUI application to crash when configuring the virtual things.